### PR TITLE
Minimal adjustments to install breeze

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,3 +37,4 @@ VignetteBuilder:
     rmarkdown
 Depends: 
     R (>= 2.10)
+Suggests: rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ VignetteBuilder:
     rmarkdown
 Depends: 
     R (>= 2.10)
-Suggests: rmarkdown
+Suggests: markdown

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ tree.
 You can install the development version from
 [GitHub](https://github.com/) with:
 
+** Need R Version 4
+
 ``` r
 devtools::install_github("GabrielNakamura/FishPhyloMaker", ref = "main", build_vignettes = TRUE)
 ```


### PR DESCRIPTION
Hi Gabriel, 

Prof. Yzel, ask me to try to install your package in Linux. 

Method used: 

> As standard to test installing packages. I use a clean Ubuntu docker. 

1.  Docker: with Ubuntu and then install R-base, try to install the package, get missing packages and install. 

> Result: Can't install in Ubuntu 20.04 default r-base, because some packages need R version 4. Solution: Install R 4 through some Ubuntu packages repositories. 

2. Official Docker  R-base (latest)

>  Result: After Install missing system files, get following errors:

`
   Error: processing vignette 'whichFishAdd_vignette.Rmd' failed with diagnostics:
   The 'markdown' package should be installed and declared as a dependency of the 'FishPhyloMaker' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.`

Solution: Add __markdown__ in suggests to ***DESCRIPTION*** file
** PS: Users that already has markdown installed will not get this errors. **

> **PS:** packages that are need: apt install libxml2-dev libssl-dev libcurl4-openssl-dev

